### PR TITLE
De/serialization subpackage for messenger

### DIFF
--- a/serde/byte.go
+++ b/serde/byte.go
@@ -1,0 +1,38 @@
+package serde
+
+import "io"
+
+type ByteReader struct {
+	io.Reader
+
+	b [1]byte
+}
+
+func NewByteReader(r io.Reader) *ByteReader {
+	return &ByteReader{Reader: r}
+}
+
+func (b *ByteReader) ReadByte() (byte, error) {
+	_, err := io.ReadFull(b.Reader, b.b[:])
+	if err != nil {
+		return 0, err
+	}
+
+	return b.b[0], nil
+}
+
+type byteCounter struct {
+	br io.ByteReader
+	i  *int
+}
+
+func (bc *byteCounter) ReadByte() (byte, error) {
+	b, err := bc.br.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+
+	*bc.i++
+	return b, nil
+}
+

--- a/serde/fuzz.go
+++ b/serde/fuzz.go
@@ -1,0 +1,68 @@
+//go:build gofuzz
+// +build gofuzz
+
+package serde
+
+import "io"
+
+func Fuzz(data []byte) int {
+	rw := &testRW{}
+	in := &fakeMsg{data: data}
+
+	n, err := Write(rw, in)
+	if err != nil {
+		return 0
+	}
+
+	out := &fakeMsg{}
+	nn, err := Read(rw, out)
+	if err != nil {
+		return 0
+	}
+
+	if n != nn {
+		panic("read/write not equal")
+	}
+	return 1
+}
+
+type testRW struct {
+	buf  []byte
+	r, w int // read, written
+}
+
+func (rw *testRW) Write(b []byte) (n int, err error) {
+	if len(rw.buf) == rw.w {
+		rw.buf = append(rw.buf, make([]byte, len(b))...)
+	}
+	n = copy(rw.buf[rw.w:], b)
+	rw.w += n
+	return
+}
+
+func (rw *testRW) Read(b []byte) (n int, err error) {
+	if len(rw.buf) == rw.r {
+		return 0, io.EOF
+	}
+	n = copy(b, rw.buf[rw.r:])
+	rw.r += n
+	return
+}
+
+type fakeMsg struct {
+	data []byte
+}
+
+func (f *fakeMsg) Size() int {
+	return len(f.data)
+}
+
+func (f *fakeMsg) MarshalTo(buf []byte) (int, error) {
+	return copy(buf, f.data), nil
+}
+
+func (f *fakeMsg) Unmarshal(data []byte) error {
+	f.data = make([]byte, len(data))
+	copy(f.data, data)
+	return nil
+}

--- a/serde/serde.go
+++ b/serde/serde.go
@@ -1,0 +1,76 @@
+package serde
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	pool "github.com/libp2p/go-buffer-pool"
+)
+
+type Message interface {
+	Size() int
+	MarshalTo([]byte) (int, error)
+	Unmarshal([]byte) error
+}
+
+func Marshal(msg Message, buf []byte) (n int, err error) {
+	n = binary.PutUvarint(buf, uint64(msg.Size()))
+	nn, err := msg.MarshalTo(buf[n:])
+	n += nn
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func Unmarshal(msg Message, data []byte) (n int, err error) {
+	vint, n := binary.Uvarint(data)
+	if n < 0 {
+		return 0, fmt.Errorf("serde: varint overflow")
+	}
+
+	nn := n + int(vint)
+	err = msg.Unmarshal(data[n:nn])
+	if err != nil {
+		return
+	}
+
+	return nn, nil
+}
+
+func Write(w io.Writer, msg Message) (n int, err error) {
+	s := msg.Size()
+	buf := pool.Get(uvarintSize(uint64(s)) + s)
+	defer pool.Put(buf)
+
+	n, err = Marshal(msg, buf)
+	if err != nil {
+		return
+	}
+
+	return w.Write(buf[:n])
+}
+
+func Read(r io.Reader, msg Message) (n int, err error) {
+	size, err := binary.ReadUvarint(&byteCounter{NewByteReader(r), &n})
+	if err != nil {
+		return
+	}
+
+	buf := pool.Get(int(size))
+	nn, err := readWith(r, msg, buf)
+	n += nn
+	pool.Put(buf)
+	return
+}
+
+func readWith(r io.Reader, msg Message, buf []byte) (int, error) {
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+
+	return n, msg.Unmarshal(buf)
+}

--- a/serde/serde_test.go
+++ b/serde/serde_test.go
@@ -1,0 +1,85 @@
+package serde
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalUnmarshal(t *testing.T) {
+	in := &fakeMsg{data: []byte("test")}
+	buf := make([]byte, 100)
+
+	n, err := Marshal(in, buf)
+	require.Nil(t, err)
+	assert.Greater(t, n, in.Size())
+
+	out := &fakeMsg{}
+	nn, err := Unmarshal(out, buf)
+	require.Nil(t, err)
+	assert.Equal(t, n, nn)
+
+	assert.Equal(t, in, out)
+}
+
+func TestWriteRead(t *testing.T) {
+	in := &fakeMsg{data: []byte("test")}
+	rw := &testRW{}
+
+	n, err := Write(rw, in)
+	require.Nil(t, err)
+	assert.NotZero(t, n)
+	assert.Equal(t, n, rw.w)
+	assert.NotEqual(t, n, in.Size())
+
+	out := &fakeMsg{}
+	nn, err := Read(rw, out)
+	require.Nil(t, err)
+	assert.NotZero(t, nn)
+	assert.Equal(t, nn, rw.r)
+	assert.Equal(t, n, nn)
+	assert.Equal(t, in, out)
+}
+
+type testRW struct {
+	buf  []byte
+	r, w int // read, written
+}
+
+func (rw *testRW) Write(b []byte) (n int, err error) {
+	if len(rw.buf) == rw.w {
+		rw.buf = append(rw.buf, make([]byte, len(b))...)
+	}
+	n = copy(rw.buf[rw.w:], b)
+	rw.w += n
+	return
+}
+
+func (rw *testRW) Read(b []byte) (n int, err error) {
+	if len(rw.buf) == rw.r {
+		return 0, io.EOF
+	}
+	n = copy(b, rw.buf[rw.r:])
+	rw.r += n
+	return
+}
+
+type fakeMsg struct {
+	data []byte
+}
+
+func (f *fakeMsg) Size() int {
+	return len(f.data)
+}
+
+func (f *fakeMsg) MarshalTo(buf []byte) (int, error) {
+	return copy(buf, f.data), nil
+}
+
+func (f *fakeMsg) Unmarshal(data []byte) error {
+	f.data = make([]byte, len(data))
+	copy(f.data, data)
+	return nil
+}

--- a/serde/varint.go
+++ b/serde/varint.go
@@ -1,0 +1,13 @@
+package serde
+
+import "math/bits"
+
+func uvarintSize(num uint64) int {
+	bits := bits.Len64(num)
+	q, r := bits/7, bits%7
+	size := q
+	if r > 0 || size == 0 {
+		size++
+	}
+	return size
+}


### PR DESCRIPTION
This PR introduces `serde` - a de/serialization library for length-delimited messages to be sent over the wire. It provides:
* A Message interface for a variety of serialization formats(currently focuses on protobuf)
* Un/marshaling for the Message.
* Stream Read/Write API for the Message.
* Allocated byte buffer pooling.
* Fuzzing testing 

TODO: godoc