### PR TITLE
refactor: remove redundant error channel on msg sent API

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -21,8 +21,8 @@ var errClosed = errors.New("msngr: closed")
 
 // Messenger provides a simple API to send messages to multiple peers.
 type Messenger struct {
-	host host.Host
-	pids []protocol.ID
+	host  host.Host
+	pids  []protocol.ID
 	msgTp reflect.Type
 
 	// fields below are used and protected in processIn
@@ -36,8 +36,8 @@ type Messenger struct {
 	newStreamsOut  chan inet.Stream
 	deadStreamsOut chan inet.Stream
 	streamsOut     map[peer.ID]map[inet.Stream]context.CancelFunc
-	peersOut  map[peer.ID]chan *msgWrap
-	peersReqs chan chan []peer.ID
+	peersOut       map[peer.ID]chan *msgWrap
+	peersReqs      chan chan []peer.ID
 
 	ctx    context.Context
 	cancel context.CancelFunc

--- a/messenger_in.go
+++ b/messenger_in.go
@@ -77,7 +77,7 @@ func (m *Messenger) msgsIn(ctx context.Context, s inet.Stream) {
 				return
 			}
 
-			if errors.Is(err, io.EOF) {
+			if errors.Is(err, io.EOF) || errors.Is(err, inet.ErrReset) {
 				return
 			}
 			log.Errorw("reading message", "from", from.ShortString(), "err", err)

--- a/messenger_out.go
+++ b/messenger_out.go
@@ -157,7 +157,6 @@ func (m *Messenger) msgsOut(ctx context.Context, s inet.Stream, out <-chan *msgW
 		select {
 		case msg := <-out: // out is not going to be closed, thus no 'ok' check
 			_, err := serde.Write(s, msg)
-			msg.Done(err)
 			if err != nil {
 				log.Errorw("writing message", "to", msg.to.ShortString(), "err", err)
 				s.Reset()

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -312,7 +312,7 @@ func TestPeers(t *testing.T) {
 	}
 
 	// have to wait till everyone ready
-	time.Sleep(time.Millisecond*100)
+	time.Sleep(time.Millisecond * 100)
 
 	for _, m := range ms {
 		peers := m.Peers()

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -278,7 +278,9 @@ func TestGroupBroadcast(t *testing.T) {
 
 	// do actual broadcasting
 	for _, m := range ms {
-		m.Broadcast(ctx, randPlainMessage(100))
+		peers, err := m.Broadcast(ctx, randPlainMessage(100))
+		require.NoError(t, err)
+		assert.Len(t, peers, netSize-1)
 	}
 
 	// actually check everyone received a message from everyone

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -47,8 +47,8 @@ func TestSend_PeersConnected(t *testing.T) {
 	require.NoError(t, err)
 
 	msgin := randPlainMessage(256)
-	done := min.Send(ctx, msgin, mnet.Peers()[1])
-	require.NoError(t, <-done)
+	err = min.Send(ctx, msgin, mnet.Peers()[1])
+	require.NoError(t, err)
 
 	msgout, from, err := mout.Receive(ctx)
 	require.NoError(t, err)
@@ -77,8 +77,8 @@ func TestSend_PeersDisconnected(t *testing.T) {
 	require.NoError(t, err)
 
 	msgin := randPlainMessage(256)
-	done := min.Send(ctx, msgin, mnet.Peers()[1])
-	require.NoError(t, <-done)
+	err = min.Send(ctx, msgin, mnet.Peers()[1])
+	require.NoError(t, err)
 
 	msgout, from, err := mout.Receive(ctx)
 	require.NoError(t, err)
@@ -196,8 +196,8 @@ func TestStreamDuplicates(t *testing.T) {
 	require.NoError(t, err)
 
 	msgout = randPlainMessage(256)
-	done := min.Send(ctx, msgout, hosts[1].ID())
-	require.NoError(t, <-done)
+	err = min.Send(ctx, msgout, hosts[1].ID())
+	require.NoError(t, err)
 
 	err = h("", sin)
 	require.NoError(t, err)
@@ -235,10 +235,10 @@ func TestSend_Events(t *testing.T) {
 	assert.Equal(t, evt.Peer, firstHst.ID())
 	assert.Equal(t, evt.Connectedness, network.Connected)
 
-	done := first.Send(ctx, randPlainMessage(256), secondHst.ID())
-	assert.NoError(t, <-done)
-	done = second.Send(ctx, randPlainMessage(256), firstHst.ID())
-	assert.NoError(t, <-done)
+	err = first.Send(ctx, randPlainMessage(256), secondHst.ID())
+	assert.NoError(t, err)
+	err = second.Send(ctx, randPlainMessage(256), firstHst.ID())
+	assert.NoError(t, err)
 
 	_, from, err := first.Receive(ctx)
 	assert.NoError(t, err)


### PR DESCRIPTION
But also: 
* [don't log out stream reset](https://github.com/celestiaorg/go-libp2p-messenger/commit/c01c846cd9476b6c53be2d134e77a89bc532bc2c)
* [feat: broadcast to return the peers to whom the msg was sent](https://github.com/celestiaorg/go-libp2p-messenger/commit/088c06f024b94df85990e97a81460dc41c9e9dd2)
* [chore: update comments and new error type](https://github.com/celestiaorg/go-libp2p-messenger/commit/2934a39d77affa6c74969b3970ee0a6a798a0486)

Closes #15 