### PR TITLE
docs: fix godoc for `Broadcast`

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -105,11 +105,12 @@ func (m *Messenger) Receive(ctx context.Context) (serde.Message, peer.ID, error)
 	}
 }
 
-// Broadcast optimistically sends the given message 'out' to each connected peer speaking *the same* protocol.
-// It returns a slice od peers to whom the message was sent and errors in case the given ctx was closed or
-// in case when Messenger is closed.
-// WARNING: It should be used deliberately. Avoid use cases requiring message propagation to a whole protocol network,
-//  not to flood the network with message duplicates. For such cases use libp2p.PubSub instead.
+// Broadcast optimistically sends the given message 'out' to each connected peer
+// speaking *the same* protocol. It returns a slice of peers to whom the message
+// was sent and errors in case the given ctx was closed or in case when
+// Messenger is closed. WARNING: It should be used deliberately. Avoid use cases
+// requiring message propagation to a whole protocol network, not to flood the
+// network with message duplicates. For such cases use libp2p.PubSub instead.
 func (m *Messenger) Broadcast(ctx context.Context, out serde.Message) (peer.IDSlice, error) {
 	bcast := make(chan peer.IDSlice, 1)
 	err := m.send(ctx, &msgWrap{


### PR DESCRIPTION
## Description

Fixed a typo (`od` => `of`) and unintentional code block in the godoc for `Broadcast`

## Screenshot

Before | After
--- | ---
<img width="1133" alt="before" src="https://user-images.githubusercontent.com/3699047/194573148-004f19dc-8c15-4595-b2ef-e1b76b78e091.png"> | <img width="857" alt="after" src="https://user-images.githubusercontent.com/3699047/194573155-722bf638-5a46-4484-b28a-e73093cf72de.png">
