### PR TITLE
refactor!: extended Message interface

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,0 +1,36 @@
+package msngr
+
+import (
+	"github.com/celestiaorg/go-libp2p-messenger/serde"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type Message interface {
+	serde.Message
+
+	To() peer.ID
+	From() peer.ID
+
+	New(from, to peer.ID) Message
+}
+
+type PlainMessage struct {
+	serde.PlainMessage
+
+	from, to peer.ID
+}
+
+func (p *PlainMessage) To() peer.ID {
+	return p.to
+}
+
+func (p *PlainMessage) From() peer.ID {
+	return p.from
+}
+
+func (p *PlainMessage) New(from, to peer.ID) Message {
+	return &PlainMessage{
+		from: from,
+		to:   to,
+	}
+}

--- a/messenger.go
+++ b/messenger.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
 	inet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-
-	"github.com/celestiaorg/go-libp2p-messenger/serde"
 )
 
 var log = logging.Logger("msngr")
@@ -26,18 +25,21 @@ type Messenger struct {
 	msgTp reflect.Type
 
 	// fields below are used and protected in processIn
-	inbound       chan *msgWrap
+	inbound       chan Message
 	newStreamsIn  chan inet.Stream
 	deadStreamsIn chan inet.Stream
 	streamsIn     map[peer.ID]map[inet.Stream]context.CancelFunc
 
 	// fields below are used and protected by processOut
-	outbound       chan *msgWrap
+	outbound       chan Message
 	newStreamsOut  chan inet.Stream
 	deadStreamsOut chan inet.Stream
 	streamsOut     map[peer.ID]map[inet.Stream]context.CancelFunc
-	peersOut       map[peer.ID]chan *msgWrap
-	peersReqs      chan chan []peer.ID
+	peersOut       map[peer.ID]chan Message
+	peersReqs      chan chan peer.IDSlice
+	broadcastMu    sync.Mutex
+	broadcast      chan Message
+	broadcastPeers chan peer.IDSlice
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -50,17 +52,19 @@ func New(host host.Host, opts ...Option) (*Messenger, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &Messenger{
 		host:           host,
-		msgTp:          reflect.TypeOf(serde.PlainMessage{}),
-		inbound:        make(chan *msgWrap, 32),
+		msgTp:          reflect.TypeOf(PlainMessage{}),
+		inbound:        make(chan Message, 32),
 		newStreamsIn:   make(chan inet.Stream, 4),
 		deadStreamsIn:  make(chan inet.Stream, 2),
 		streamsIn:      make(map[peer.ID]map[inet.Stream]context.CancelFunc),
-		outbound:       make(chan *msgWrap, 32),
+		outbound:       make(chan Message, 32),
 		newStreamsOut:  make(chan inet.Stream, 4),
 		deadStreamsOut: make(chan inet.Stream, 2),
 		streamsOut:     make(map[peer.ID]map[inet.Stream]context.CancelFunc),
-		peersOut:       make(map[peer.ID]chan *msgWrap),
-		peersReqs:      make(chan chan []peer.ID),
+		peersOut:       make(map[peer.ID]chan Message),
+		peersReqs:      make(chan chan peer.IDSlice),
+		broadcast:      make(chan Message, 1),
+		broadcastPeers: make(chan peer.IDSlice),
 		ctx:            ctx,
 		cancel:         cancel,
 	}
@@ -84,24 +88,28 @@ func (m *Messenger) Host() host.Host {
 // It errors in case the given ctx was closed or in case when Messenger is closed.
 // All messages are sent in a per peer queue, so the ordering of sent messages is guaranteed.
 // In case the Messenger is given with a RoutedHost, It tries to connect to the peer, if not connected.
-func (m *Messenger) Send(ctx context.Context, out serde.Message, to peer.ID) error {
-	return m.send(ctx, &msgWrap{
-		Message: out,
-		to:      to,
-	})
+func (m *Messenger) Send(ctx context.Context, out Message) error {
+	select {
+	case m.outbound <- out:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.ctx.Done():
+		return errClosed
+	}
 }
 
 // Receive awaits for incoming messages from peers.
 // It receives messages sent through both Send and Broadcast.
 // It errors only if the given context 'ctx' is closed or when Messenger is closed.
-func (m *Messenger) Receive(ctx context.Context) (serde.Message, peer.ID, error) {
+func (m *Messenger) Receive(ctx context.Context) (Message, error) {
 	select {
 	case msg := <-m.inbound:
-		return msg.Message, msg.from, nil
+		return msg, nil
 	case <-ctx.Done():
-		return nil, "", ctx.Err()
+		return nil, ctx.Err()
 	case <-m.ctx.Done():
-		return nil, "", errClosed
+		return nil, errClosed
 	}
 }
 
@@ -111,18 +119,24 @@ func (m *Messenger) Receive(ctx context.Context) (serde.Message, peer.ID, error)
 // Messenger is closed. WARNING: It should be used deliberately. Avoid use cases
 // requiring message propagation to a whole protocol network, not to flood the
 // network with message duplicates. For such cases use libp2p.PubSub instead.
-func (m *Messenger) Broadcast(ctx context.Context, out serde.Message) (peer.IDSlice, error) {
-	bcast := make(chan peer.IDSlice, 1)
-	err := m.send(ctx, &msgWrap{
-		Message: out,
-		bcast:   bcast,
-	})
-	if err != nil {
-		return nil, err
-	}
+func (m *Messenger) Broadcast(ctx context.Context, out Message) (peer.IDSlice, error) {
+	// ensures synchronization between broadcasting and broadcastPeers
+	m.broadcastMu.Lock()
+	defer m.broadcastMu.Unlock()
 
 	select {
-	case peers := <-bcast:
+	case m.broadcast <- out:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-m.ctx.Done():
+		return nil, errClosed
+	}
+
+	// wait for the peers we sent msgs to
+	// NOTE: the global response channel is used to avoid allocations of some msg wrapper struct
+	//  with response chan
+	select {
+	case peers := <-m.broadcastPeers:
 		return peers, nil
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -132,8 +146,8 @@ func (m *Messenger) Broadcast(ctx context.Context, out serde.Message) (peer.IDSl
 }
 
 // Peers returns a list of connected/immediate peers speaking the protocol registered on the Messenger.
-func (m *Messenger) Peers() []peer.ID {
-	req := make(chan []peer.ID, 1)
+func (m *Messenger) Peers() peer.IDSlice {
+	req := make(chan peer.IDSlice, 1)
 	select {
 	case m.peersReqs <- req:
 		select {
@@ -152,22 +166,4 @@ func (m *Messenger) Close() error {
 	m.cancel()
 	m.deinit()
 	return nil
-}
-
-func (m *Messenger) send(ctx context.Context, msg *msgWrap) error {
-	select {
-	case m.outbound <- msg:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-m.ctx.Done():
-		return errClosed
-	}
-}
-
-type msgWrap struct {
-	serde.Message
-
-	from, to peer.ID
-	bcast    chan peer.IDSlice
 }

--- a/messenger_in.go
+++ b/messenger_in.go
@@ -62,14 +62,11 @@ func (m *Messenger) msgsIn(ctx context.Context, s inet.Stream) {
 	defer s.Close()
 	r := bufio.NewReader(s)
 
-	from := s.Conn().RemotePeer()
-	var msg *msgWrap
+	from, to := s.Conn().RemotePeer(), s.Conn().LocalPeer()
+	msg := reflect.New(m.msgTp).Interface().(Message)
 	for {
-		msg = &msgWrap{
-			Message: reflect.New(m.msgTp).Interface().(serde.Message),
-			from:    from,
-		}
-		_, err := serde.Read(r, msg.Message)
+		msg = msg.New(from, to)
+		_, err := serde.Read(r, msg)
 		if err != nil {
 			select {
 			case m.deadStreamsIn <- s:

--- a/net.go
+++ b/net.go
@@ -28,7 +28,7 @@ func (m *Messenger) init() {
 				switch cevt.Connectedness {
 				case network.Connected:
 					m.connected(cevt.Peer)
-				// we don't care about NotConnected case, as it is handled by observing stream being reset
+					// we don't care about NotConnected case, as it is handled by observing stream being reset
 				}
 			case <-m.ctx.Done():
 				err := sub.Close()


### PR DESCRIPTION
Similarly to the previous API, this allows users to send custom msgs. The difference is that destination, and source peers of the msg are now part of the Message interface contract. This provides zero allocation way to send msgs! No internal msgWrapper allocations for both Send and Broadcast methods.

Additionally, this is preparation for the new generics version.

Also includes minor test deflakes.